### PR TITLE
devops: add Dockerfiles for backend and frontend dev environments

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,3 @@
+bin/
+vendor
+*.log

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,15 @@
+FROM golang:1.24-alpine
+
+RUN apk add --no-cache git curl && \
+    go install github.com/air-verse/air@latest
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["air"]

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.log

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,14 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+ENV NODE_ENV=development
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
### Summary
This PR introduces Dockerfiles for the Go backend and Svelte frontend tailored for local development.
It establishes a container-based workflow that aligns with future objectives of staging and production deployments.

### Related Issue
Closes #4 - Add Dockerfiles for backend and frontend dev environments